### PR TITLE
Fix: Add base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  base: '/device-orientation-demo/',
   root: '.',
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Problem
The JavaScript file was returning a 404 error in production deployment because the assets were being referenced with an incorrect path.

## Solution
Added `base: '/device-orientation-demo/'` to `vite.config.ts` to ensure that all assets are correctly referenced relative to the GitHub Pages repository path.

## Changes
- Updated `vite.config.ts` to include the base path configuration

## Testing
After this PR is merged and deployed, the JavaScript file will be accessible at `/device-orientation-demo/assets/index-[hash].js` and the orientation sensor button will work correctly in production.

Fixes #19