### PR TITLE
Add 3D visualization with dual viewport comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ Visit the live demo at: https://cyrfer.github.io/device-orientation-demo/
 - **TypeScript Implementation**: Type-safe codebase with modern JavaScript features
 - **Vite Development Environment**: Fast development server with hot module replacement
 - **Real-time Euler Angle Display**: Shows alpha (Z-axis), beta (X-axis), and gamma (Y-axis) values
-- **Compass Heading Calculation & Normalization Toggle**: Implements the [W3C worked example](https://www.w3.org/TR/orientation-event/#worked-example) to calculate true compass heading, with an option to display heading in either 0°–360° or normalized -180°–+180° range
+- **Compass Heading Calculation**: Implements the [W3C worked example](https://www.w3.org/TR/orientation-event/#worked-example) to calculate true compass heading, elevation, and roll angles
+- **3D Visualization**: Interactive Three.js visualization showing how rotation matrices transform geometry
+  - **Data Tab**: Traditional display of orientation angles and heading
+  - **3D View Tab**: Side-by-side comparison of two rotation methods:
+    - Left viewport: Geometry rotated using the raw device orientation matrix
+    - Right viewport: Geometry rotated using a matrix reconstructed from extracted angles (heading, elevation, roll)
+  - **Responsive Layout**: Viewports display side-by-side in landscape mode, stacked vertically in portrait mode
 - **Mobile-Friendly Interface**: Responsive design optimized for mobile devices
 - **iOS 13+ Permission Handling**: Properly requests device orientation permissions on iOS devices
 - **Visual Feedback**: Clean, modern UI with real-time updates
@@ -64,12 +70,16 @@ npm run type-check
 1. Start the development server with `npm run dev` or open `index.html` directly in a mobile device browser
 2. Click "Enable Device Orientation" button
 3. Grant permission when prompted (iOS devices)
-4. The app will display:
-   - Alpha: Rotation around Z-axis (0° to 360°)
-   - Beta: Front-to-back tilt (-180° to 180°)
-   - Gamma: Left-to-right tilt (-90° to 90°)
+4. **Data Tab** displays:
    - Compass Heading: Calculated direction in degrees and cardinal direction (N, NE, E, SE, S, SW, W, NW)
-   - **Heading Range Toggle**: Use the checkbox to switch between 0°–360° and -180°–+180° display for compass heading. The normalized range is useful for applications needing signed heading values.
+   - Elevation: Pitch angle (-90° to +90°)
+   - Roll: Bank angle (-180° to +180°)
+   - Raw device orientation values (Alpha, Beta, Gamma)
+5. **3D View Tab** shows:
+   - Two synchronized 3D viewports with a colored cube and axis arrows (X=red, Y=green, Z=blue)
+   - Left viewport: Rotated using the raw device orientation rotation matrix
+   - Right viewport: Rotated using a matrix built from extracted angles (R = R(roll) × R(elevation) × R(heading))
+   - Compare both visualizations to verify that the angle extraction preserves the rotation accurately across Android and iOS
 
 ## Browser Compatibility
 
@@ -86,18 +96,25 @@ The compass heading calculation uses the worked example from the [W3C Device Ori
 3. Using arctangent to determine heading
 4. Normalizing to 0-360 degrees
 
-### Heading Normalization Feature
-The app includes a toggle to display compass heading in either the standard 0°–360° range or a normalized -180°–+180° range. When enabled, headings greater than 180° are shown as negative values (e.g., 270° becomes -90°). This is useful for applications that require signed heading values for easier interpretation of left/right orientation.
+### 3D Visualization Details
+The 3D visualization demonstrates platform unification by showing that despite different raw sensor values on Android and iOS:
+- The raw device orientation matrix produces a specific rotation
+- Extracting angles (heading, elevation, roll) from transformed vectors
+- Reconstructing a rotation matrix from those angles (R = R(roll) × R(elevation) × R(heading))
+- Both matrices produce visually identical rotations, confirming the mathematical consistency
+
+This allows developers to verify cross-platform behavior by viewing both devices side-by-side and confirming the 3D visualizations match.
 
 ## Project Structure
 
 ```
 ├── src/
-│   └── main.ts          # TypeScript source code
-├── index.html           # Main HTML file
-├── package.json         # Node.js dependencies and scripts
-├── tsconfig.json        # TypeScript configuration
-├── vite.config.ts       # Vite configuration
+│   ├── main.ts              # TypeScript main logic and orientation handling
+│   └── visualization.ts     # Three.js 3D visualization scenes
+├── index.html               # Main HTML file with tab interface
+├── package.json             # Node.js dependencies and scripts
+├── tsconfig.json            # TypeScript configuration
+├── vite.config.ts           # Vite configuration
 └── README.md           # This file
 ```
 

--- a/index.html
+++ b/index.html
@@ -14,18 +14,23 @@
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
+            height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: flex-start;
             padding: 8px;
             color: #fff;
+            overflow: hidden;
         }
 
         .container {
             width: 100%;
             max-width: 500px;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
         }
 
         h1 {
@@ -131,19 +136,110 @@
             margin-top: 10px;
             line-height: 1.5;
         }
+
+        /* Tab Navigation */
+        .tabs {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 10px;
+        }
+
+        .tab-button {
+            flex: 1;
+            padding: 12px;
+            font-size: 16px;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.7);
+            background: rgba(255, 255, 255, 0.2);
+            border: 2px solid transparent;
+            border-radius: 10px;
+            cursor: pointer;
+            transition: all 0.3s;
+        }
+
+        .tab-button.active {
+            color: #fff;
+            background: rgba(255, 255, 255, 0.3);
+            border-color: rgba(255, 255, 255, 0.5);
+        }
+
+        .tab-content {
+            display: none;
+        }
+
+        .tab-content.active {
+            display: flex;
+            flex-direction: column;
+        }
+
+        /* 3D Visualization Container */
+        #tab-visualization {
+            flex: 1;
+            min-height: 0;
+        }
+
+        /* 3D Visualization */
+        .viewports-container {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            width: 100%;
+            height: 100%;
+        }
+
+        @media (orientation: landscape) {
+            .viewports-container {
+                flex-direction: row;
+            }
+        }
+
+        .viewport-wrapper {
+            flex: 1;
+            background: rgba(255, 255, 255, 0.95);
+            border-radius: 15px;
+            padding: 10px;
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
+        }
+
+        .viewport-title {
+            font-weight: 600;
+            color: #667eea;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 8px;
+            text-align: center;
+        }
+
+        .viewport-canvas {
+            flex: 1;
+            width: 100%;
+            border-radius: 10px;
+            background: #1a1a2e;
+            display: block;
+            min-height: 0;
+        }
     </style>
 </head>
 <body>
     <div class="container">
         <h1>Device Orientation Demo</h1>
         
+        <!-- Tab Navigation -->
+        <div class="tabs">
+            <button class="tab-button active" data-tab="data">Data</button>
+            <button class="tab-button" data-tab="visualization">3D View</button>
+        </div>
+        
         <button id="requestButton">
             Enable Device Orientation
         </button>
 
-        <div class="status" id="status">
-            Ready to start. Click the button to begin.
-        </div>
+        <!-- Tab 1: Data View (Current UI) -->
+        <div class="tab-content active" id="tab-data">
         
         <!-- Main outputs: Heading, Elevation, Roll -->
         <div class="card compass">
@@ -180,6 +276,23 @@
                 </div>
             </div>
         </div>
+
+        </div> <!-- End Tab 1: Data View -->
+
+        <!-- Tab 2: 3D Visualization -->
+        <div class="tab-content" id="tab-visualization">
+            <div class="viewports-container">
+                <div class="viewport-wrapper">
+                    <div class="viewport-title">Raw Device Matrix</div>
+                    <canvas class="viewport-canvas" id="canvas-raw"></canvas>
+                </div>
+                <div class="viewport-wrapper">
+                    <div class="viewport-title">Extracted Angles Matrix</div>
+                    <canvas class="viewport-canvas" id="canvas-extracted"></canvas>
+                </div>
+            </div>
+        </div>
+
     </div>
 
     <script type="module" src="/src/main.ts"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "device-orientation-demo",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@types/three": "^0.181.0",
+        "three": "^0.181.0"
+      },
       "devDependencies": {
         "@tsconfig/node22": "^22.0.0",
         "typescript": "^5.9.3",
@@ -16,6 +20,11 @@
       "engines": {
         "node": ">=22.0.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -725,11 +734,45 @@
       "integrity": "sha512-Kmwj4u8sDRDrMYRoN9FDEcXD8UpBSaPQQ24Gz+Gamqfm7xxn+GBR7ge/Z7pK8OXNGyUzbSwJj+TH6B+DS/epyA==",
       "dev": true
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="
+    },
+    "node_modules/@types/three": {
+      "version": "0.181.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.181.0.tgz",
+      "integrity": "sha512-MLF1ks8yRM2k71D7RprFpDb9DOX0p22DbdPqT/uAkc6AtQXjxWCVDjCy23G9t1o8HcQPk7woD2NIyiaWcWPYmA==",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
+      "integrity": "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA=="
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -789,6 +832,11 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -802,6 +850,11 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -916,6 +969,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/three": {
+      "version": "0.181.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.181.0.tgz",
+      "integrity": "sha512-KGf6EOCOQGshXeleKxpxhbowQwAXR2dLlD93egHtZ9Qmk07Saf8sXDR+7wJb53Z1ORZiatZ4WGST9UsVxhHEbg=="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "dependencies": {
+    "@types/three": "^0.181.0",
+    "three": "^0.181.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { VisualizationScene } from './visualization';
-import { Vector3, Matrix3x3 } from './mathTypes';
+import { Vector3, Matrix3x3, multiplyMatrices, multiplyMatrixVector } from './mathTypes';
 
 // State variables
 let rawScene: VisualizationScene | null = null;
@@ -40,21 +40,6 @@ function normalizeHeadingRange(heading: number): number {
         heading -= 360;
     }
     return heading;
-}
-
-// Dot product: takes two vectors and returns the sum of component-wise multiplication
-function dotProduct(v1: Vector3, v2: Vector3): number {
-    return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2];
-}
-
-// Matrix-vector multiplication: result = matrix × vector
-// Each component of the result is the dot product of the corresponding matrix row with the vector
-function multiplyMatrixVector(matrix: Matrix3x3, vector: Vector3): Vector3 {
-    return [
-        dotProduct(matrix[0], vector),
-        dotProduct(matrix[1], vector),
-        dotProduct(matrix[2], vector),
-    ];
 }
 
 // Build the rotation matrix from Euler angles (alpha, beta, gamma)
@@ -159,23 +144,6 @@ function buildRotationMatrixFromAngles(heading: number, elevation: number, roll:
     const R: Matrix3x3 = multiplyMatrices(Rr, ReRh);
 
     return R;
-}
-
-// Matrix multiplication: result = A × B
-function multiplyMatrices(A: Matrix3x3, B: Matrix3x3): Matrix3x3 {
-    const result: Matrix3x3 = [
-        [0, 0, 0],
-        [0, 0, 0],
-        [0, 0, 0]
-    ];
-
-    for (let i = 0; i < 3; i++) {
-        for (let j = 0; j < 3; j++) {
-            result[i][j] = A[i][0] * B[0][j] + A[i][1] * B[1][j] + A[i][2] * B[2][j];
-        }
-    }
-
-    return result;
 }
 
 // Handle device orientation event

--- a/src/mathTypes.ts
+++ b/src/mathTypes.ts
@@ -1,0 +1,3 @@
+// Type definitions for linear algebra
+export type Vector3 = [number, number, number];
+export type Matrix3x3 = [Vector3, Vector3, Vector3];

--- a/src/mathTypes.ts
+++ b/src/mathTypes.ts
@@ -1,3 +1,51 @@
-// Type definitions for linear algebra
-export type Vector3 = [number, number, number];
-export type Matrix3x3 = [Vector3, Vector3, Vector3];
+
+export type Vector3 = [ number, number, number ];
+
+export type Matrix3x3 = [
+  Vector3,
+  Vector3,
+  Vector3
+];
+
+
+// Dot product: takes two vectors and returns the sum of component-wise multiplication
+export function dotProduct(v1: Vector3, v2: Vector3): number {
+  return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
+}
+
+// Matrix-vector multiplication: result = matrix × vector
+// Each component of the result is the dot product of the corresponding matrix row with the vector
+export function multiplyMatrixVector(matrix: Matrix3x3, vector: Vector3): Vector3 {
+  return [
+    dotProduct(matrix[0], vector),
+    dotProduct(matrix[1], vector),
+    dotProduct(matrix[2], vector),
+  ];
+}
+
+
+// Matrix multiplication: result = A × B
+export function multiplyMatrices(
+  A: Matrix3x3,
+  B: Matrix3x3
+): Matrix3x3 {
+  const result: Matrix3x3 = [
+    [0, 0, 0],
+    [0, 0, 0],
+    [0, 0, 0]
+  ];
+
+  for (let r = 0; r < 3; r++) {
+    const row = A[r];
+    for (let c = 0; c < 3; c++) {
+      const col: Vector3 = [
+        B[0][c],
+        B[1][c],
+        B[2][c]
+      ];
+      result[r][c] = dotProduct(row, col);
+    }
+  }
+
+  return result;
+}

--- a/src/mathTypes.ts
+++ b/src/mathTypes.ts
@@ -49,3 +49,69 @@ export function multiplyMatrices(
 
   return result;
 }
+
+
+// Build the rotation matrix from Euler angles (alpha, beta, gamma)
+// Based on the W3C Device Orientation Event specification
+// https://www.w3.org/TR/orientation-event/#worked-example
+// https://www.w3.org/TR/orientation-event/equation13a.png
+export function buildRotationMatrix(alphaRad: number, betaRad: number, gammaRad: number): Matrix3x3 {
+    const cA = Math.cos(alphaRad);
+    const sA = Math.sin(alphaRad);
+    const cB = Math.cos(betaRad);
+    const sB = Math.sin(betaRad);
+    const cG = Math.cos(gammaRad);
+    const sG = Math.sin(gammaRad);
+
+    // Full rotation matrix R from equation13a.png
+    return [
+        [cA*cG - sA*sB*sG,  -cB*sA,        cG*sA*sB + cA*sG],
+        [cG*sA + cA*sB*sG,   cA*cB,        sA*sG - cA*cG*sB],
+        [-cB*sG,             sB,            cB*cG          ],
+    ];
+}
+
+
+// Build rotation matrix from extracted angles (roll, elevation, heading)
+// Order: R = R(roll) * R(elevation) * R(heading)
+// This constructs a rotation matrix from the extracted angles to compare with the raw device matrix
+export function buildRotationMatrixFromAngles(heading: number, elevation: number, roll: number): Matrix3x3 {
+
+    // Convert degrees to radians
+    const h = heading * (Math.PI / 180);
+    const e = elevation * (Math.PI / 180);
+    const r = roll * (Math.PI / 180);
+
+    // Heading rotation (around Y-axis)
+    const ch = Math.cos(-h);
+    const sh = Math.sin(-h);
+    const Rh: Matrix3x3 = [
+        [ch, 0, sh],
+        [0, 1, 0],
+        [-sh, 0, ch]
+    ];
+
+    // Elevation rotation (around X-axis)
+    const ce = Math.cos(e);
+    const se = Math.sin(e);
+    const Re: Matrix3x3 = [
+        [1, 0, 0],
+        [0, ce, -se],
+        [0, se, ce]
+    ];
+
+    // Roll rotation (around Z-axis)
+    const cr = Math.cos(-r);
+    const sr = Math.sin(-r);
+    const Rr: Matrix3x3 = [
+        [cr, -sr, 0],
+        [sr, cr, 0],
+        [0, 0, 1]
+    ];
+
+
+    const RhRe: Matrix3x3 = multiplyMatrices(Rh, Re);
+    const R: Matrix3x3 = multiplyMatrices(RhRe, Rr);
+
+    return R;
+}

--- a/src/visualization.ts
+++ b/src/visualization.ts
@@ -1,0 +1,156 @@
+import * as THREE from 'three';
+import { Matrix3x3 } from './mathTypes';
+
+// Apply a 3x3 rotation matrix to a THREE.Matrix4
+// The 3x3 matrix represents the rotation component, which is placed in the upper-left
+// of the 4x4 matrix with the rest being identity (no translation, uniform scale of 1)
+function setMatrix4FromMatrix3x3(matrix4: THREE.Matrix4, m: Matrix3x3): void {
+    matrix4.set(
+        m[0][0], m[0][1], m[0][2], 0,
+        m[1][0], m[1][1], m[1][2], 0,
+        m[2][0], m[2][1], m[2][2], 0,
+        0,       0,       0,       1
+    );
+}
+
+export class VisualizationScene {
+    private scene: THREE.Scene;
+    private camera: THREE.PerspectiveCamera;
+    private renderer: THREE.WebGLRenderer;
+    private cube: THREE.Mesh;
+    private arrowX: THREE.ArrowHelper;
+    private arrowY: THREE.ArrowHelper;
+    private arrowZ: THREE.ArrowHelper;
+    private group: THREE.Group;
+
+    constructor(canvas: HTMLCanvasElement) {
+        // Scene setup
+        this.scene = new THREE.Scene();
+        this.scene.background = new THREE.Color(0x1a1a2e);
+
+        // Camera setup
+        this.camera = new THREE.PerspectiveCamera(
+            75,
+            canvas.clientWidth / canvas.clientHeight,
+            0.1,
+            1000
+        );
+        // Position camera directly behind the geometry along +Z axis
+        this.camera.position.set(0, 0, 5);
+        this.camera.lookAt(0, 0, 0);
+
+        // Renderer setup
+        this.renderer = new THREE.WebGLRenderer({ 
+            canvas, 
+            antialias: true 
+        });
+        this.renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+        // Create group to hold all objects
+        this.group = new THREE.Group();
+        this.scene.add(this.group);
+
+        // Create cube with distinct faces
+        const geometry = new THREE.BoxGeometry(1, 1, 1);
+        const materials = [
+            new THREE.MeshBasicMaterial({ color: 0xff6b6b, wireframe: false }), // right - red
+            new THREE.MeshBasicMaterial({ color: 0xff9999, wireframe: false }), // left - light red
+            new THREE.MeshBasicMaterial({ color: 0x4ecdc4, wireframe: false }), // top - cyan
+            new THREE.MeshBasicMaterial({ color: 0x95e1d3, wireframe: false }), // bottom - light cyan
+            new THREE.MeshBasicMaterial({ color: 0xf7b731, wireframe: false }), // front - yellow
+            new THREE.MeshBasicMaterial({ color: 0xfeca57, wireframe: false }), // back - light yellow
+        ];
+        this.cube = new THREE.Mesh(geometry, materials);
+        
+        // Add wireframe overlay to cube
+        const wireframeGeometry = new THREE.EdgesGeometry(geometry);
+        const wireframeMaterial = new THREE.LineBasicMaterial({ color: 0x000000, linewidth: 2 });
+        const wireframe = new THREE.LineSegments(wireframeGeometry, wireframeMaterial);
+        this.cube.add(wireframe);
+        
+        this.group.add(this.cube);
+
+        // Create axis arrows
+        // X-axis (red) - points to the right in initial orientation
+        this.arrowX = new THREE.ArrowHelper(
+            new THREE.Vector3(1, 0, 0),
+            new THREE.Vector3(0, 0, 0),
+            1.5,
+            0xff0000,
+            0.3,
+            0.2
+        );
+        this.group.add(this.arrowX);
+
+        // Y-axis (green) - points up in initial orientation
+        this.arrowY = new THREE.ArrowHelper(
+            new THREE.Vector3(0, 1, 0),
+            new THREE.Vector3(0, 0, 0),
+            1.5,
+            0x00ff00,
+            0.3,
+            0.2
+        );
+        this.group.add(this.arrowY);
+
+        // Z-axis (blue) - points toward viewer in initial orientation
+        this.arrowZ = new THREE.ArrowHelper(
+            new THREE.Vector3(0, 0, 1),
+            new THREE.Vector3(0, 0, 0),
+            1.5,
+            0x0000ff,
+            0.3,
+            0.2
+        );
+        this.group.add(this.arrowZ);
+
+        // Add ambient light for better visibility
+        const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
+        this.scene.add(ambientLight);
+
+        const directionalLight = new THREE.DirectionalLight(0xffffff, 0.4);
+        directionalLight.position.set(5, 5, 5);
+        this.scene.add(directionalLight);
+
+        // Start animation loop
+        this.animate();
+    }
+
+    private animate = (): void => {
+        requestAnimationFrame(this.animate);
+        this.renderer.render(this.scene, this.camera);
+    };
+
+    // Update rotation using a 3x3 rotation matrix
+    public updateRotation(rotationMatrix: Matrix3x3): void {
+        // Convert 3x3 matrix to THREE.Matrix4
+        const matrix4 = new THREE.Matrix4();
+        setMatrix4FromMatrix3x3(matrix4, rotationMatrix);
+
+        // Apply rotation to the group
+        this.group.setRotationFromMatrix(matrix4);
+    }
+
+    // Handle window resize
+    public resize(): void {
+        const canvas = this.renderer.domElement;
+        const width = canvas.clientWidth;
+        const height = canvas.clientHeight;
+
+        this.camera.aspect = width / height;
+        this.camera.updateProjectionMatrix();
+
+        this.renderer.setSize(width, height);
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    }
+
+    // Clean up resources
+    public dispose(): void {
+        this.renderer.dispose();
+        this.cube.geometry.dispose();
+        if (Array.isArray(this.cube.material)) {
+            this.cube.material.forEach(mat => mat.dispose());
+        }
+    }
+}

--- a/src/visualization.ts
+++ b/src/visualization.ts
@@ -18,12 +18,11 @@ export class VisualizationScene {
     private camera: THREE.PerspectiveCamera;
     private renderer: THREE.WebGLRenderer;
     private cube: THREE.Mesh;
-    private arrowX: THREE.ArrowHelper;
-    private arrowY: THREE.ArrowHelper;
-    private arrowZ: THREE.ArrowHelper;
+    private arrowForward: THREE.ArrowHelper;
+    private arrowRight: THREE.ArrowHelper;
     private group: THREE.Group;
 
-    constructor(canvas: HTMLCanvasElement) {
+    constructor(canvas: HTMLCanvasElement, cameraPos: [number, number, number]) {
         // Scene setup
         this.scene = new THREE.Scene();
         this.scene.background = new THREE.Color(0x1a1a2e);
@@ -36,7 +35,7 @@ export class VisualizationScene {
             1000
         );
         // Position camera directly behind the geometry along +Z axis
-        this.camera.position.set(0, 0, 5);
+        this.camera.position.set(cameraPos[0], cameraPos[1], cameraPos[2]);
         this.camera.lookAt(0, 0, 0);
 
         // Renderer setup
@@ -54,7 +53,7 @@ export class VisualizationScene {
         // Create cube with distinct faces
         const geometry = new THREE.BoxGeometry(1, 1, 1);
         const materials = [
-            new THREE.MeshBasicMaterial({ color: 0xff6b6b, wireframe: false }), // right - red
+            new THREE.MeshBasicMaterial({ color: 0xff0000, wireframe: false }), // right - red
             new THREE.MeshBasicMaterial({ color: 0xff9999, wireframe: false }), // left - light red
             new THREE.MeshBasicMaterial({ color: 0x4ecdc4, wireframe: false }), // top - cyan
             new THREE.MeshBasicMaterial({ color: 0x95e1d3, wireframe: false }), // bottom - light cyan
@@ -71,39 +70,27 @@ export class VisualizationScene {
         
         this.group.add(this.cube);
 
-        // Create axis arrows
-        // X-axis (red) - points to the right in initial orientation
-        this.arrowX = new THREE.ArrowHelper(
+        // create "forward" (north) arrow
+        this.arrowForward = new THREE.ArrowHelper(
+            new THREE.Vector3(0, 0, -1),
+            new THREE.Vector3(0, 0, 0),
+            5,
+            0x3333ff,
+            0.5,
+            0.4
+        );
+        this.group.add(this.arrowForward);
+
+        // create "right" (east) arrow
+        this.arrowRight = new THREE.ArrowHelper(
             new THREE.Vector3(1, 0, 0),
             new THREE.Vector3(0, 0, 0),
-            1.5,
+            5,
             0xff0000,
-            0.3,
-            0.2
+            0.5,
+            0.4
         );
-        this.group.add(this.arrowX);
-
-        // Y-axis (green) - points up in initial orientation
-        this.arrowY = new THREE.ArrowHelper(
-            new THREE.Vector3(0, 1, 0),
-            new THREE.Vector3(0, 0, 0),
-            1.5,
-            0x00ff00,
-            0.3,
-            0.2
-        );
-        this.group.add(this.arrowY);
-
-        // Z-axis (blue) - points toward viewer in initial orientation
-        this.arrowZ = new THREE.ArrowHelper(
-            new THREE.Vector3(0, 0, 1),
-            new THREE.Vector3(0, 0, 0),
-            1.5,
-            0x0000ff,
-            0.3,
-            0.2
-        );
-        this.group.add(this.arrowZ);
+        this.group.add(this.arrowRight);
 
         // Add ambient light for better visibility
         const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);


### PR DESCRIPTION
- Add Three.js dependency for 3D rendering
- Implement tab navigation (Data tab and 3D View tab)
- Create VisualizationScene class with cube and axis arrows
- Add two viewports showing side-by-side comparison:
  * Left: geometry rotated by raw device orientation matrix
  * Right: geometry rotated by matrix built from extracted angles
- Optimize vertical space usage with flexbox layout
- Support responsive layout (side-by-side in landscape, stacked in portrait)
- Create shared mathTypes.ts for Vector3 and Matrix3x3 types
- Position camera at (0,0,5) for head-on view of geometry
- Remove status card to conserve screen real estate
- Update README with new features and usage instructions

Closes #23 
